### PR TITLE
bug: Remove default password for single-pod config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ help:
 .PHONY: ocp-create
 ocp-create: check-kustomize
 	-oc new-project freeipa
-	$(MAKE) -C $(OCP_CONFIG) configure &> /dev/null
+	$(MAKE) -C $(OCP_CONFIG) configure
 	# cd $(OCP_CONFIG) && $(OCP_KUSTOMIZE) edit set image main=$(OCP_IMAGE)
 	$(OCP_KUSTOMIZE) build config/rbac | oc create -f -
 	$(OCP_KUSTOMIZE) build $(OCP_CONFIG) | oc create -f - --as=freeipa

--- a/config/static/single-pod/Makefile
+++ b/config/static/single-pod/Makefile
@@ -6,8 +6,10 @@ SINGLEPOD_HOSTNAME := $(SINGLEPOD_NAMESPACE).apps.$(SINGLEPOD_BASEDOMAIN)
 SINGLEPOD_CA_SUBJECT := CN=freeipa-$(shell date +%Y%m%d%H%M%S ), O=$(SINGLEPOD_REALM)
 SINGLEPOD_ENV_FILE := env.properties
 
-SINGLEPOD_PASSWORD ?= Secret123
 SINGLEPOD_SECRETS_FILE := secrets.properties
+ifeq (,$(SINGLEPOD_PASSWORD))
+$(error "SINGLEPOD_PASSWORD is required for generating the secret with the password; you can set it before call 'make'")
+endif
 
 .PHONY: configure
 configure:


### PR DESCRIPTION
- Remove line which assign the default password.
- Add check and abort Makefile if the variable
  was not provided.

signed-off-by: Alejandro Visiedo <avisiedo@redhat.com>